### PR TITLE
Fix incompatible pointer type assignments

### DIFF
--- a/_perlin.c
+++ b/_perlin.c
@@ -291,7 +291,7 @@ static struct PyModuleDef moduledef = {
 PyObject *
 PyInit__perlin(void)
 {
-    PERM = &DEFAULTPERM;
+    PERM = DEFAULTPERM;
     return PyModule_Create(&moduledef);
 }
 

--- a/_simplex.c
+++ b/_simplex.c
@@ -394,7 +394,7 @@ randomize(PyObject *self, PyObject *args, PyObject *kwargs)
         if(PERM==NULL)
         {    
             period=DEFAULTPERIOD;
-            PERM = &DEFAULTPERM;
+            PERM = DEFAULTPERM;
             PyErr_SetString(PyExc_ValueError, "Failed to allocate memory");
             return NULL;
         }
@@ -467,7 +467,7 @@ static struct PyModuleDef moduledef = {
 PyObject *
 PyInit__simplex(void)
 {
-    PERM = &DEFAULTPERM;
+    PERM = DEFAULTPERM;
     return PyModule_Create(&moduledef);
 }
 


### PR DESCRIPTION
Upon building, I got errors like this:
```
Building wheels for collected packages: noise_randomized
  Building wheel for noise_randomized (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for noise_randomized (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      running bdist_wheel
      running build
      running build_py
      copying ./shader.py -> build/lib.linux-x86_64-cpython-312/noise_randomized
      copying ./__init__.py -> build/lib.linux-x86_64-cpython-312/noise_randomized
      copying ./perlin.py -> build/lib.linux-x86_64-cpython-312/noise_randomized
      copying ./test.py -> build/lib.linux-x86_64-cpython-312/noise_randomized
      copying ./shader_noise.py -> build/lib.linux-x86_64-cpython-312/noise_randomized
      running build_ext
      building 'noise_randomized._simplex' extension
      gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -I/home/lukas/git/noise-randomized/venv/include -I/usr/include/python3.12 -c _simplex.c -o build/temp.linux-x86_64-cpython-312/_simplex.o -funroll-loops
      _simplex.c: In function ‘randomize’:
      _simplex.c:391:17: warning: comparison of distinct pointer types lacks a cast [-Wcompare-distinct-pointer-types]
        391 |         if(PERM != &DEFAULTPERM)
            |                 ^~
      _simplex.c:397:18: error: assignment to ‘unsigned char *’ from incompatible pointer type ‘unsigned char (*)[512]’ [-Wincompatible-pointer-types]
        397 |             PERM = &DEFAULTPERM;
            |                  ^
      _simplex.c: In function ‘PyInit__simplex’:
      _simplex.c:470:10: error: assignment to ‘unsigned char *’ from incompatible pointer type ‘unsigned char (*)[512]’ [-Wincompatible-pointer-types]
        470 |     PERM = &DEFAULTPERM;
            |          ^
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for noise_randomized
Failed to build noise_randomized
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (noise_randomized)
```
Removing the dereference from `DEFAULTPERM` fixes these issues.